### PR TITLE
Remove unnecessary instructions in Contributing.cshtml

### DIFF
--- a/src/Snppts/Views/Home/Contributing.cshtml
+++ b/src/Snppts/Views/Home/Contributing.cshtml
@@ -32,7 +32,7 @@
                         <h3>Add your first snippet</h3>
                         <div class="separator-2 mb-20"></div>
                         <p>
-                            To add a snippet you can fork this project, add your snippet to the <strong>Snippets</strong> folder as a class, implementing the <strong>IAmASnippet</strong> interface. If you are doing this via the GitHub editor, don't forget to add the class to the .csproj.
+                            To add a snippet you can fork this project, add your snippet to the <strong>Snippets</strong> folder as a class, implementing the <strong>IAmASnippet</strong> interface.
                         </p>
                         <p>
                             The result should look something like this:

--- a/src/Snppts/Views/Home/Contributing.cshtml
+++ b/src/Snppts/Views/Home/Contributing.cshtml
@@ -16,7 +16,7 @@
 
                         <h3>Add yourself as an author</h3>
                         <div class="separator-2 mb-20"></div>
-                        <p>To add yourself as a Snppts author you can fork this project, add yourself to the authors folder as a class, implementing the <strong>IAmAnAuthor</strong> interface. If you are doing this via the GitHub editor, don't forget to add the class to the .csproj.</p>
+                        <p>To add yourself as a Snppts author you can fork this project, add yourself to the authors folder as a class, implementing the <strong>IAmAnAuthor</strong> interface.</p>
                         <p>The result should look something like this:</p>
                         <script src="https://gist.github.com/sthewissen/83e363a44d6fb573edbaefae43c6daba.js"></script>
                         <p>


### PR DESCRIPTION
Since you use the new csproj SDK, users do not need to add the author file in the .csproj.