### PR TITLE
Add screenshots for the stories, profile, ranking and store

### DIFF
--- a/src/Snppts/Snippets/DuolingoClone.cs
+++ b/src/Snppts/Snippets/DuolingoClone.cs
@@ -9,7 +9,7 @@ namespace Snppts.Snippets
     {
         public string Slug => "duolingo-clone";
         public string Title => "Duolingo Clone";
-        public string Description => "A Duolingo clone app made with Xamarin.Forms. At moment, this app only contains the lessons page, the tab bar structure and custom navigation bar for each page. Some custom renders was created for the floating action button in Android, tab bar and circular progress bar.";
+        public string Description => "A clone of the Duolingo app made with Xamarin.Forms. At moment, this app contains the lessons, stories, profile, ranking, store, the tab bar structure and custom navigation bar for each page. Some custom renderers was created for the floating action button in Android, tab bar and circular / horizontal progress bar.";
         public string GithubRepoName => "ionixjunior/XFAppDuolingoClone";
         public Uri ExternalUri => new Uri("https://www.ionixjunior.com.br/duolingo-app-clone-com-xamarin-forms/");
         public bool ContainsAndroidSample => true;
@@ -23,15 +23,34 @@ namespace Snppts.Snippets
             new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_lessons_1.png"),
             new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_lessons_2.png"),
             new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_lessons_3.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_stories_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_stories_2.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_profile_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_profile_2.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_profile_3.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_profile_4.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_ranking_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_store_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_store_2.png"),
             new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_lessons_1.png"),
             new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_lessons_2.png"),
-            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_lessons_3.png")
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_lessons_3.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_stories_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_profile_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_profile_2.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_profile_3.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_profile_4.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_ranking_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_store_1.png"),
+            new Uri("https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_store_2.png")
         };
 
         public IList<Category> Categories => new List<Category>
         {
             Category.DASHBOARD,
-            Category.TABBARS
+            Category.TABBARS,
+            Category.APPCLONE,
+            Category.LISTS
         };
     }
 }


### PR DESCRIPTION
## Duolingo Clone screenshots update

Some screenshots was added in Duolingo Clone app:

<kbd><img height="350" src="https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_stories_1.png" /></kbd><kbd><img height="350" src="https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_profile_1.png" /></kbd><kbd><img height="350" src="https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_profile_3.png" /></kbd><kbd><img height="350" src="https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/android_ranking_1.png" /></kbd><kbd><img height="350" src="https://raw.githubusercontent.com/ionixjunior/XFAppDuolingoClone/master/art/ios_store_1.png" /></kbd>