### PR TITLE
Added music streaming stats snippet

### DIFF
--- a/src/Snppts/Authors/MichalDivis.cs
+++ b/src/Snppts/Authors/MichalDivis.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Snppts.Infrastructure;
+
+namespace Snppts.Authors
+{
+    public class MichalDivis : IAmAnAuthor
+    {
+        public string FirstName => "Michal";
+        public string LastName => "Diviš";
+        public Uri Website => new Uri("https://github.com/michaldivis");
+        public string TwitterHandle => "";
+        public string GitHubHandle => "michaldivis";
+        public string EmailAddress => "michall.divis@gmail.com";
+        public string GravatarHash => "4284b13ced272ede8c9703f0605ed694";
+    }
+}

--- a/src/Snppts/Snippets/MusicStreamingStats.cs
+++ b/src/Snppts/Snippets/MusicStreamingStats.cs
@@ -1,0 +1,37 @@
+﻿using Snppts.Authors;
+using Snppts.Extensions;
+using Snppts.Infrastructure;
+using System;
+using System.Collections.Generic;
+
+namespace Snppts.Snippets
+{
+    public class MusicStreamingStats : IAmASnippet
+    {
+        public string Slug => "music-streaming-stats";
+        public string Title => "Music Streaming Stats";
+        public GitHubRepoInfo GitHubRepoInfo => new GitHubRepoInfo("michaldivis/music-streaming-stats-ui");
+        public bool ContainsAndroidSample => true;
+        public bool ContainsiOSSample => true;
+        public bool ContainsUWPSample => false;
+
+        public string Description => "A simple music streaming stats dashboard app, similar to Spotify for Artists.";
+
+        public IAmAnAuthor AuthorInfo => new MichalDivis();
+
+        public IEnumerable<Uri> ImageUris => new List<Uri>
+        {
+            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/android_1.png?raw=true"),
+            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/android_2.png?raw=true"),
+            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/ios_1.png?raw=true"),
+            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/ios_2.png?raw=true"),
+        };
+
+        public IList<Category> Categories => new List<Category>
+        {
+            Category.DASHBOARD
+        };
+
+        public Uri ExternalUri => null;
+    }
+}

--- a/src/Snppts/Snippets/MusicStreamingStats.cs
+++ b/src/Snppts/Snippets/MusicStreamingStats.cs
@@ -21,10 +21,7 @@ namespace Snppts.Snippets
 
         public IEnumerable<Uri> ImageUris => new List<Uri>
         {
-            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/android_1.png?raw=true"),
-            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/android_2.png?raw=true"),
-            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/ios_1.png?raw=true"),
-            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/ios_2.png?raw=true"),
+            new Uri("https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/android.png?raw=true")
         };
 
         public IList<Category> Categories => new List<Category>


### PR DESCRIPTION
## Submission description

I've added a music streaming stats dashboard snippet, similar to Spotify for Artists.

The sample uses gradients, borders, and a Lottie animation (SkiaSharp.Extended).

<img src="https://github.com/michaldivis/music-streaming-stats-ui/blob/master/screenshots/android.png?raw=true" height="500" />

### Possible platform improvements

One thing I'm missing in MAUI so far is a better Image control. I've been using FFImageLoading in Xamarin.Forms which hasn't been ported to MAUI and now I'm missing the ability to show loading placeholders, error placeholders, and so on.
